### PR TITLE
Fix for CMS block retrieval issue on Magento 2.4

### DIFF
--- a/src/Model/Resolver/DataProvider/Block.php
+++ b/src/Model/Resolver/DataProvider/Block.php
@@ -11,6 +11,7 @@ namespace ScandiPWA\CmsGraphQl\Model\Resolver\DataProvider;
 
 use Magento\Cms\Api\BlockRepositoryInterface;
 use Magento\Cms\Api\Data\BlockInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\CmsGraphQl\Model\Resolver\DataProvider\Block as CoreBlock;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Widget\Model\Template\FilterEmulate;
@@ -34,13 +35,17 @@ class Block extends CoreBlock
     /**
      * @param BlockRepositoryInterface $blockRepository
      * @param FilterEmulate $widgetFilter
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
      */
     public function __construct(
         BlockRepositoryInterface $blockRepository,
-        FilterEmulate $widgetFilter
+        FilterEmulate $widgetFilter,
+        SearchCriteriaBuilder $searchCriteriaBuilder
     ) {
         $this->blockRepository = $blockRepository;
         $this->widgetFilter = $widgetFilter;
+
+        parent::__construct($blockRepository, $widgetFilter, $searchCriteriaBuilder);
     }
 
     /**


### PR DESCRIPTION
CMS block retrieval throws error in Magento 2.4 as a `getBlocksData` function from `Magento\CmsGraphQl\Model\Resolver\Blocks` is using functions from `Magento\CmsGraphQl\Model\Resolver\DataProvider\Block` and requires `SearchCriteriaBuilder`

Code in the PR ensures parent calss has `$this->searchCriteriaBuilder`

This fix makes CMS block retrieval work. More comprehensive solution for possible changes in Magento 2.4.