### PR TITLE
Missing $variables  fix

### DIFF
--- a/src/etc/graphql/di.xml
+++ b/src/etc/graphql/di.xml
@@ -17,6 +17,7 @@
 
     <virtualType name="ScandiPWA\CmsGraphQl\Model\Template\VirtualFilter" type="ScandiPWA\CmsGraphQl\Model\Template\Filter">
         <arguments>
+            <argument name="variables" xsi:type="array" />
             <argument name="availableFilters" xsi:type="array">
                 <item name="Slider" xsi:type="string">Scandiweb\Slider\Block\Widget\Slider</item>
                 <item name="NewProducts" xsi:type="string">Magento\Catalog\Block\Product\Widget\NewWidget</item>


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3318

**Problem:**
* Virtual type filter isn't passing variable `$variaibles` while DI isn't rebuilded.

**In this PR:**
* Added default value for `$variables`